### PR TITLE
feat: 新增errorHandler相关测试用例

### DIFF
--- a/packages/base/__test__/utils.spec.ts
+++ b/packages/base/__test__/utils.spec.ts
@@ -80,6 +80,7 @@ describe('utils', async () => {
     isOldEdge,
     isOpenHarmony,
     isPromise,
+    isObject,
     isQuickApp,
     isSafari,
     isString,
@@ -430,6 +431,28 @@ describe('utils', async () => {
       expect(isAsyncFunc('')).toBe(false);
       expect(isAsyncFunc(0 / 1)).toBe(false);
     });
+
+    it('isObject', () => {
+      expect(isObject({})).toBe(true);
+      expect(isObject(null)).toBe(false);
+      expect(isObject(undefined)).toBe(false);
+      expect(isObject(0)).toBe(false);
+      expect(isObject('')).toBe(false);
+      expect(isObject(0 / 1)).toBe(false);
+      expect(isObject(new Date())).toBe(true);
+      expect(isObject(new Error())).toBe(true);
+      expect(isObject(new Map())).toBe(true);
+      expect(isObject(new WeakMap())).toBe(true);
+      expect(isObject(new Set())).toBe(true);
+      expect(isObject(new WeakSet())).toBe(true);
+      expect(isObject(new Promise(() => {}))).toBe(true);
+      expect(isObject(new Int8Array())).toBe(true);
+      expect(isObject(new Uint8Array())).toBe(true);
+      expect(isObject(new Uint8ClampedArray())).toBe(true);
+      expect(isObject(new Int16Array())).toBe(true);
+      expect(isObject(new Uint16Array())).toBe(true);
+      expect(isObject(new File(Buffer.from('test'), 'test.txt', { type: 'text/plain' }))).toBe(true);
+    })
   });
 
   describe('funcHandler', () => {

--- a/packages/base/__test__/utils.spec.ts
+++ b/packages/base/__test__/utils.spec.ts
@@ -119,7 +119,10 @@ describe('utils', async () => {
     throttle,
     getSpace,
     tryOrErrorFunc,
-    tryOrErrorAsyncFunc
+    tryOrErrorAsyncFunc,
+    tryOrError,
+    tryOrErrorAsync,
+    resultOrError
   } = await (() => {
     return inject('CI') ? import('../dist') : import('../src');
   })() as typeof import('../src');
@@ -654,16 +657,28 @@ describe('utils', async () => {
         return 'pass';
       }
 
+      const resolveResult = Promise.resolve(func('pass'));
+      const rejectResult = Promise.reject(presetError);
+
       const obj = {
         func: tryOrErrorFunc(func),
         asyncFunc: tryOrErrorAsyncFunc(func)
       };
 
-      expect(obj.func('this')).toStrictEqual([null, obj]);
+      expect(tryOrError(() => func('pass'))).toEqual([null, 'pass']);
+      expect(tryOrError(() => func('error'))).toEqual([presetError, null])
+
+      expect(tryOrErrorAsync(async () => func('pass'))).resolves.toEqual([null, 'pass']);
+      expect(tryOrErrorAsync(async () => func('error'))).resolves.toEqual([presetError, null])
+
+      expect(resultOrError(resolveResult)).resolves.toEqual([null, 'pass']);
+      expect(resultOrError(rejectResult)).resolves.toEqual([presetError, null])
+
+      expect(obj.func('this')).toEqual([null, obj]);
       expect(obj.func('error')).toEqual([presetError, null])
       expect(obj.func('pass')).toEqual([null, 'pass']);
 
-      expect(obj.asyncFunc('this')).resolves.toStrictEqual([null, obj]);
+      expect(obj.asyncFunc('this')).resolves.toEqual([null, obj]);
       expect(obj.asyncFunc('error')).resolves.toEqual([presetError, null])
       expect(obj.asyncFunc('pass')).resolves.toEqual([null, 'pass']);
     })

--- a/packages/base/__test__/utils.spec.ts
+++ b/packages/base/__test__/utils.spec.ts
@@ -439,19 +439,19 @@ describe('utils', async () => {
       expect(isObject(0)).toBe(false);
       expect(isObject('')).toBe(false);
       expect(isObject(0 / 1)).toBe(false);
-      expect(isObject(new Date())).toBe(true);
-      expect(isObject(new Error())).toBe(true);
-      expect(isObject(new Map())).toBe(true);
-      expect(isObject(new WeakMap())).toBe(true);
-      expect(isObject(new Set())).toBe(true);
-      expect(isObject(new WeakSet())).toBe(true);
-      expect(isObject(new Promise(() => {}))).toBe(true);
-      expect(isObject(new Int8Array())).toBe(true);
-      expect(isObject(new Uint8Array())).toBe(true);
-      expect(isObject(new Uint8ClampedArray())).toBe(true);
-      expect(isObject(new Int16Array())).toBe(true);
-      expect(isObject(new Uint16Array())).toBe(true);
-      expect(isObject(new File(Buffer.from('test'), 'test.txt', { type: 'text/plain' }))).toBe(true);
+      expect(isObject(NaN)).toBe(false);
+      expect(isObject(new Date())).toBe(false);
+      expect(isObject(new Error())).toBe(false);
+      expect(isObject(new Map())).toBe(false);
+      expect(isObject(new WeakMap())).toBe(false);
+      expect(isObject(new Set())).toBe(false);
+      expect(isObject(new WeakSet())).toBe(false);
+      expect(isObject(new Promise(() => {}))).toBe(false);
+      expect(isObject(new Int8Array())).toBe(false);
+      expect(isObject(new Uint8Array())).toBe(false);
+      expect(isObject(new Uint8ClampedArray())).toBe(false);
+      expect(isObject(new Int16Array())).toBe(false);
+      expect(isObject(new Uint16Array())).toBe(false);
     })
   });
 

--- a/packages/base/__test__/utils.spec.ts
+++ b/packages/base/__test__/utils.spec.ts
@@ -81,6 +81,7 @@ describe('utils', async () => {
     isOpenHarmony,
     isPromise,
     isObject,
+    isPlainObject,
     isQuickApp,
     isSafari,
     isString,
@@ -439,19 +440,40 @@ describe('utils', async () => {
       expect(isObject(0)).toBe(false);
       expect(isObject('')).toBe(false);
       expect(isObject(0 / 1)).toBe(false);
-      expect(isObject(NaN)).toBe(false);
-      expect(isObject(new Date())).toBe(false);
-      expect(isObject(new Error())).toBe(false);
-      expect(isObject(new Map())).toBe(false);
-      expect(isObject(new WeakMap())).toBe(false);
-      expect(isObject(new Set())).toBe(false);
-      expect(isObject(new WeakSet())).toBe(false);
-      expect(isObject(new Promise(() => {}))).toBe(false);
-      expect(isObject(new Int8Array())).toBe(false);
-      expect(isObject(new Uint8Array())).toBe(false);
-      expect(isObject(new Uint8ClampedArray())).toBe(false);
-      expect(isObject(new Int16Array())).toBe(false);
-      expect(isObject(new Uint16Array())).toBe(false);
+      expect(isObject(new Date())).toBe(true);
+      expect(isObject(new Error())).toBe(true);
+      expect(isObject(new Map())).toBe(true);
+      expect(isObject(new WeakMap())).toBe(true);
+      expect(isObject(new Set())).toBe(true);
+      expect(isObject(new WeakSet())).toBe(true);
+      expect(isObject(new Promise(() => {}))).toBe(true);
+      expect(isObject(new Int8Array())).toBe(true);
+      expect(isObject(new Uint8Array())).toBe(true);
+      expect(isObject(new Uint8ClampedArray())).toBe(true);
+      expect(isObject(new Int16Array())).toBe(true);
+      expect(isObject(new Uint16Array())).toBe(true);
+      expect(isObject(new File(Buffer.from('test'), 'test.txt', { type: 'text/plain' }))).toBe(true);
+    })
+
+    it('isPlainObject', () => {
+      expect(isPlainObject({})).toBe(true);
+      expect(isPlainObject(null)).toBe(false);
+      expect(isPlainObject(undefined)).toBe(false);
+      expect(isPlainObject(0)).toBe(false);
+      expect(isPlainObject('')).toBe(false);
+      expect(isPlainObject(0 / 1)).toBe(false);
+      expect(isPlainObject(new Date())).toBe(false);
+      expect(isPlainObject(new Error())).toBe(false);
+      expect(isPlainObject(new Map())).toBe(false);
+      expect(isPlainObject(new WeakMap())).toBe(false);
+      expect(isPlainObject(new Set())).toBe(false);
+      expect(isPlainObject(new WeakSet())).toBe(false);
+      expect(isPlainObject(new Promise(() => {}))).toBe(false);
+      expect(isPlainObject(new Int8Array())).toBe(false);
+      expect(isPlainObject(new Uint8Array())).toBe(false);
+      expect(isPlainObject(new Uint8ClampedArray())).toBe(false);
+      expect(isPlainObject(new Int16Array())).toBe(false);
+      expect(isPlainObject(new Uint16Array())).toBe(false);
     })
   });
 

--- a/packages/base/src/utils/func-handler/transform.ts
+++ b/packages/base/src/utils/func-handler/transform.ts
@@ -234,7 +234,9 @@ export function tryCallFunc<F extends TAnyFunc>(
  * @param func
  */
 export function tryOrErrorFunc<T extends any[], R>(func: TFunc<T, R>): (...args: T) => ErrorResult<R> {
-  return (...args: T) => tryOrError(() => func(...args));
+  return function (this: any, ...args: T) {
+    return tryOrError(() => func.call(this, ...args));
+  };
 }
 
 /**
@@ -244,5 +246,7 @@ export function tryOrErrorFunc<T extends any[], R>(func: TFunc<T, R>): (...args:
  * @param func
  */
 export function tryOrErrorAsyncFunc<T extends any[], R>(func: TFunc<T, R>): (...args: T) => Promise<ErrorResult<R>> {
-  return (...args: T) => tryOrErrorAsync(() => func(...args));
+  return function (this: any, ...args: T) {
+    return tryOrErrorAsync(() => func.call(this, ...args));
+  };
 }

--- a/packages/base/src/utils/verify/object.ts
+++ b/packages/base/src/utils/verify/object.ts
@@ -56,6 +56,6 @@ export function isObject(value: any): value is object {
  * 判断是否为普通字面量对象
  * @param value
  */
-export function isPlainObject(value: any): value is object {
+export function isPlainObject(value: any): value is Record<string, unknown> {
   return getType(value) === 'object';
 }

--- a/packages/base/src/utils/verify/object.ts
+++ b/packages/base/src/utils/verify/object.ts
@@ -42,3 +42,11 @@ export const isBlob = cacheByReturn(() => {
   }
   return (value: any): boolean => value instanceof Blob;
 });
+
+/**
+ * 判断是否为Object对象
+ * @param value
+ */
+export function isObject(value: any): value is object {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/base/src/utils/verify/object.ts
+++ b/packages/base/src/utils/verify/object.ts
@@ -1,5 +1,6 @@
 import { warning } from '$/common/warning';
 import { cacheByReturn } from '../func-handler';
+import { getType } from '../get-data';
 import { isInIframe } from '../ua';
 
 /**
@@ -44,9 +45,9 @@ export const isBlob = cacheByReturn(() => {
 });
 
 /**
- * 判断是否为Object对象
+ * 判断是否为普通字面量对象
  * @param value
  */
 export function isObject(value: any): value is object {
-  return typeof value === 'object' && value !== null;
+  return getType(value) === 'object';
 }

--- a/packages/base/src/utils/verify/object.ts
+++ b/packages/base/src/utils/verify/object.ts
@@ -45,7 +45,7 @@ export const isBlob = cacheByReturn(() => {
 });
 
 /**
- * 判断是否为Object对象
+ * 判断是否为引用类型数据
  * @param value
  */
 export function isObject(value: any): value is object {
@@ -53,7 +53,7 @@ export function isObject(value: any): value is object {
 }
 
 /**
- * 判断是否为普通字面量对象
+ * 判断是否为普通对象
  * @param value
  */
 export function isPlainObject(value: any): value is Record<string, unknown> {

--- a/packages/base/src/utils/verify/object.ts
+++ b/packages/base/src/utils/verify/object.ts
@@ -1,6 +1,6 @@
 import { warning } from '$/common/warning';
+import { getType } from '..';
 import { cacheByReturn } from '../func-handler';
-import { getType } from '../get-data';
 import { isInIframe } from '../ua';
 
 /**
@@ -45,9 +45,17 @@ export const isBlob = cacheByReturn(() => {
 });
 
 /**
- * 判断是否为普通字面量对象
+ * 判断是否为Object对象
  * @param value
  */
 export function isObject(value: any): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * 判断是否为普通字面量对象
+ * @param value
+ */
+export function isPlainObject(value: any): value is object {
   return getType(value) === 'object';
 }


### PR DESCRIPTION
对tryOrErrorFunc和tryOrErrorAsyncFunc支持了原本this指向的传递，同时新增了对返回值，错误捕获，this指向相关的测试用例