### PR TITLE
fix(git-down): 修复 window 下 rename 问题

### DIFF
--- a/packages/git-down/src/download/partial.ts
+++ b/packages/git-down/src/download/partial.ts
@@ -41,6 +41,6 @@ export async function downloadPartial(state: State) {
     }, callback)
     .then(() => writeFile(sparseCheckoutPath, sparseChecoutFile), callback)
     .then(() => exec(`git pull ${randomRemoteName} --quiet ${branch} --depth 1`, execOption), callback)
-    .then(() => moveOrCopyAndCleanup(resolve(tempPath, pathname), targetPath, callback), callback)
+    .then(() => moveOrCopyAndCleanup(resolve(tempPath, pathname), targetPath), callback)
     .then(() => rmdir(tempPath), callback);
 }

--- a/packages/git-down/src/download/partial.ts
+++ b/packages/git-down/src/download/partial.ts
@@ -1,5 +1,5 @@
 import type { State } from '$/types';
-import { createOutput, exec, existsSync, mv, readFile, resolve, rmdir, writeFile } from '$/utils';
+import { createOutput, exec, existsSync, moveOrCopyAndCleanup, readFile, resolve, rmdir, writeFile } from '$/utils';
 
 export async function downloadPartial(state: State) {
   const { gitInfo, callback, option } = state;
@@ -41,6 +41,6 @@ export async function downloadPartial(state: State) {
     }, callback)
     .then(() => writeFile(sparseCheckoutPath, sparseChecoutFile), callback)
     .then(() => exec(`git pull ${randomRemoteName} --quiet ${branch} --depth 1`, execOption), callback)
-    .then(() => mv(resolve(tempPath, pathname), targetPath), callback)
+    .then(() => moveOrCopyAndCleanup(resolve(tempPath, pathname), targetPath, callback), callback)
     .then(() => rmdir(tempPath), callback);
 }

--- a/packages/git-down/src/utils.ts
+++ b/packages/git-down/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Callback, GitDownOption, GitUrlInfo } from './types';
 import { exec as execWithCallback } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { cp, mkdir, rename, rm } from 'node:fs/promises';
 import { extname } from 'node:path';
 
 import { promisify } from 'node:util';
@@ -61,4 +61,20 @@ export function parseGitUrl(url: string): GitUrlInfo {
     branch,
     pathname: filePath,
   };
+}
+
+export async function moveOrCopyAndCleanup(sourcePath: string, targetPath: string, callback: Callback): Promise<void> {
+  try {
+    // 如果目标路径已存在，使用复制
+    if (existsSync(targetPath)) {
+      await cp(sourcePath, targetPath, { recursive: true });
+    }
+    else {
+      // 如果目标不存在，使用移动（重命名）
+      await rename(sourcePath, targetPath);
+    }
+
+    callback(null);
+  }
+  catch {}
 }

--- a/packages/git-down/src/utils.ts
+++ b/packages/git-down/src/utils.ts
@@ -63,18 +63,13 @@ export function parseGitUrl(url: string): GitUrlInfo {
   };
 }
 
-export async function moveOrCopyAndCleanup(sourcePath: string, targetPath: string, callback: Callback): Promise<void> {
-  try {
-    // 如果目标路径已存在，使用复制
-    if (existsSync(targetPath)) {
-      await cp(sourcePath, targetPath, { recursive: true });
-    }
-    else {
-      // 如果目标不存在，使用移动（重命名）
-      await rename(sourcePath, targetPath);
-    }
-
-    callback(null);
+export async function moveOrCopyAndCleanup(sourcePath: string, targetPath: string) {
+  // 如果目标路径已存在，使用复制
+  if (existsSync(targetPath)) {
+    await cp(sourcePath, targetPath, { recursive: true });
   }
-  catch {}
+  else {
+    // 如果目标不存在，使用移动（重命名）
+    await rename(sourcePath, targetPath);
+  }
 }


### PR DESCRIPTION
工具名称：`git-down`
问题：
在 window 下会出现 `rename` 报错
![image](https://github.com/user-attachments/assets/f5352319-ed5b-4fc5-80af-f6caa59065c9)

测试代码：
```javascript
import gitDown from "@cmtlyt/git-down";

await gitDown(
  'https://github.com/imzbf/md-editor-v3/tree/develop',
  {
    output: 'test'
  }
)

```
