### PR TITLE
fix(git-down): 修复地址分支解析问题

### DIFF
--- a/packages/git-down/src/cli.ts
+++ b/packages/git-down/src/cli.ts
@@ -26,7 +26,6 @@ const main = defineCommand<GitDownArgsDef>({
       type: 'string',
       description: '指定要下载的分支名称',
       alias: ['b'],
-      default: 'main',
     },
     help: {
       type: 'boolean',
@@ -40,9 +39,9 @@ const main = defineCommand<GitDownArgsDef>({
       required: false,
     },
   },
-  async run({ args, rawArgs }) {
+  async run({ args }) {
     console.warn('主分支默认是 main，如果需要下载其他分支，请使用 -b 参数指定分支名称');
-    await runGitDown(args, rawArgs);
+    await runGitDown(args);
   },
 });
 

--- a/packages/git-down/src/cli.ts
+++ b/packages/git-down/src/cli.ts
@@ -40,9 +40,9 @@ const main = defineCommand<GitDownArgsDef>({
       required: false,
     },
   },
-  async run({ args }) {
+  async run({ args, rawArgs }) {
     console.warn('主分支默认是 main，如果需要下载其他分支，请使用 -b 参数指定分支名称');
-    await runGitDown(args);
+    await runGitDown(args, rawArgs);
   },
 });
 

--- a/packages/git-down/src/utils.ts
+++ b/packages/git-down/src/utils.ts
@@ -109,7 +109,7 @@ function trimLeadingSlash(value: string) {
  * 去除路径两端的斜杠，保证比较时使用统一格式
  */
 function trimSurroundingSlashes(value: string) {
-  return value.replace(/^\/+/, '').replace(/\/+$/, '');
+  return value.replace(/^\/+|\/+$/g, '');
 }
 
 /**
@@ -169,6 +169,7 @@ async function fetchRemoteBranchSet(owner: string, project: string): Promise<Set
   const promise = exec(`git ls-remote --heads https://github.com/${owner}/${project}`)
     .then(({ stdout }) => {
       const set = new Set<string>();
+      const refsHeadsPattern = /^refs\/heads\/(.+)$/;
       stdout.split(/\r?\n/)
         .map(line => line.trim())
         .filter(Boolean)
@@ -176,7 +177,7 @@ async function fetchRemoteBranchSet(owner: string, project: string): Promise<Set
           const [, ref] = line.split(/\s+/);
           if (!ref)
             return;
-          const match = ref.match(/^refs\/heads\/(.+)$/);
+          const match = ref.match(refsHeadsPattern);
           if (match?.[1])
             set.add(match[1]);
         });

--- a/packages/git-down/src/utils.ts
+++ b/packages/git-down/src/utils.ts
@@ -12,6 +12,8 @@ export { existsSync };
 
 export const exec = promisify(execWithCallback);
 
+const remoteBranchesCache = new Map<string, Promise<Set<string>>>();
+
 export async function createOutput(path: string) {
   if (existsSync(path))
     return;
@@ -25,10 +27,10 @@ export async function rmdir(path: string) {
 }
 
 export function buildOption(option?: GitDownOption): Required<GitDownOption> {
+  const normalizedBranch = option?.branch?.trim();
   return {
-    output: './git-down',
-    branch: 'main',
-    ...option,
+    output: option?.output ?? './git-down',
+    branch: normalizedBranch ?? '',
   };
 }
 
@@ -46,21 +48,198 @@ export function buildCallback(callback?: Callback) {
 }
 
 export function parseGitUrl(url: string): GitUrlInfo {
-  const pathname = url.replace(/(^https?:\/\/github\.com\/)|(^git@github\.com:)/, '/');
-  const [, owner, project, , branch = '', ...filePaths] = pathname.split('/');
+  const normalizeProject = (input: string) => input.replace(/\.git$/, '');
 
-  const filePath = filePaths.join('/');
-  const isFile = pathname.includes('blob') || Boolean(extname(filePath));
+  const httpsMatch = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)(?:\/(tree|blob)\/(.+))?/);
+  const sshMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+)(?:\/(tree|blob)\/(.+))?/);
+  const match = httpsMatch ?? sshMatch;
+
+  if (!match) {
+    return {
+      href: url,
+      owner: '',
+      project: normalizeProject(url),
+      isRepo: true,
+      sourceType: 'dir',
+      branch: '',
+      pathname: '',
+    };
+  }
+
+  const [, owner, project, mode, rawTail = ''] = match;
+  const cleanProject = normalizeProject(project);
+  const tail = rawTail ? rawTail.split(/[?#]/)[0] : '';
+
+  let branch = '';
+  let pathname = '';
+  if (tail) {
+    const firstSlashIndex = tail.indexOf('/');
+    if (firstSlashIndex === -1) {
+      branch = tail;
+    }
+    else {
+      branch = tail.slice(0, firstSlashIndex);
+      pathname = tail.slice(firstSlashIndex + 1);
+    }
+  }
+
+  const isRepo = !mode;
+  const cleanPath = pathname.replace(/^\//, '');
+  const sourceType: GitUrlInfo['sourceType'] = mode === 'blob' || (!!cleanPath && Boolean(extname(cleanPath))) ? 'file' : 'dir';
 
   return {
     href: url,
     owner,
-    project: project.replace(/\.git$/, ''),
-    isRepo: pathname.endsWith('.git') || (!pathname.includes('tree') && !pathname.includes('blob')),
-    sourceType: isFile ? 'file' : 'dir',
+    project: cleanProject,
+    isRepo,
+    sourceType,
     branch,
-    pathname: filePath,
+    pathname: cleanPath,
   };
+}
+
+/**
+ * 去除路径左侧的多余斜杠，避免拼接时出现重复分隔符
+ */
+function trimLeadingSlash(value: string) {
+  return value.replace(/^\/+/, '');
+}
+
+/**
+ * 去除路径两端的斜杠，保证比较时使用统一格式
+ */
+function trimSurroundingSlashes(value: string) {
+  return value.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * 根据显式分支信息修正 gitInfo，确保分支与路径在多级分支场景下保持一致
+ */
+export function reconcileGitInfoBranch(gitInfo: GitUrlInfo, targetBranch: string) {
+  if (!targetBranch)
+    return;
+
+  const originalBranch = trimSurroundingSlashes(gitInfo.branch);
+  const normalizedTarget = trimSurroundingSlashes(targetBranch);
+
+  gitInfo.branch = normalizedTarget;
+
+  const normalizedPath = trimLeadingSlash(gitInfo.pathname);
+
+  if (!normalizedPath)
+    return;
+
+  if (normalizedPath === normalizedTarget) {
+    gitInfo.pathname = '';
+    return;
+  }
+
+  if (normalizedPath.startsWith(`${normalizedTarget}/`)) {
+    gitInfo.pathname = normalizedPath.slice(normalizedTarget.length + 1);
+    return;
+  }
+
+  if (!originalBranch || originalBranch === normalizedTarget)
+    return;
+
+  if (!normalizedTarget.startsWith(`${originalBranch}/`))
+    return;
+
+  const remainder = normalizedTarget.slice(originalBranch.length);
+  const normalizedRemainder = trimSurroundingSlashes(remainder);
+
+  if (!normalizedRemainder)
+    return;
+
+  if (normalizedPath === normalizedRemainder) {
+    gitInfo.pathname = '';
+    return;
+  }
+
+  if (normalizedPath.startsWith(`${normalizedRemainder}/`)) {
+    gitInfo.pathname = normalizedPath.slice(normalizedRemainder.length + 1);
+  }
+}
+
+async function fetchRemoteBranchSet(owner: string, project: string): Promise<Set<string>> {
+  const cacheKey = `${owner}/${project}`;
+  if (remoteBranchesCache.has(cacheKey))
+    return remoteBranchesCache.get(cacheKey)!;
+
+  const promise = exec(`git ls-remote --heads https://github.com/${owner}/${project}`)
+    .then(({ stdout }) => {
+      const set = new Set<string>();
+      stdout.split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(Boolean)
+        .forEach((line) => {
+          const [, ref] = line.split(/\s+/);
+          if (!ref)
+            return;
+          const match = ref.match(/^refs\/heads\/(.+)$/);
+          if (match?.[1])
+            set.add(match[1]);
+        });
+      return set;
+    })
+    .catch(() => new Set<string>());
+
+  remoteBranchesCache.set(cacheKey, promise);
+  return promise;
+}
+
+export async function resolveBranchFromRemote(
+  gitInfo: GitUrlInfo,
+  explicitBranch?: string,
+  fetcher: (owner: string, project: string) => Promise<Set<string>> = fetchRemoteBranchSet,
+) {
+  const normalizedExplicit = explicitBranch?.trim();
+  if (normalizedExplicit)
+    return normalizedExplicit;
+
+  const normalizedBranch = trimSurroundingSlashes(gitInfo.branch);
+  if (!normalizedBranch)
+    return gitInfo.branch;
+
+  if (!gitInfo.owner || !gitInfo.project)
+    return gitInfo.branch;
+
+  if (!gitInfo.pathname)
+    return gitInfo.branch;
+
+  const pathSegments = gitInfo.pathname.split('/').filter(Boolean);
+  if (!pathSegments.length)
+    return gitInfo.branch;
+
+  let branches: Set<string>;
+  try {
+    branches = await fetcher(gitInfo.owner, gitInfo.project);
+  }
+  catch {
+    return gitInfo.branch;
+  }
+
+  if (!branches.size)
+    return gitInfo.branch;
+
+  for (let includeCount = pathSegments.length - 1; includeCount >= 0; includeCount--) {
+    const branchCandidate = trimSurroundingSlashes([normalizedBranch, ...pathSegments.slice(0, includeCount)].join('/'));
+    if (!branchCandidate)
+      continue;
+
+    if (!branches.has(branchCandidate))
+      continue;
+
+    const candidatePathSegments = pathSegments.slice(includeCount);
+    if (!candidatePathSegments.length)
+      continue;
+
+    gitInfo.branch = branchCandidate;
+    gitInfo.pathname = candidatePathSegments.join('/');
+    return gitInfo.branch;
+  }
+
+  return gitInfo.branch;
 }
 
 export async function moveOrCopyAndCleanup(sourcePath: string, targetPath: string) {

--- a/packages/polyfill/__test__/promise/try.test.ts
+++ b/packages/polyfill/__test__/promise/try.test.ts
@@ -19,9 +19,7 @@ describe('promise polyfill', async () => {
         throw new Error('error');
       }),
     ).rejects.toThrow('error');
-    expect(() => ClPromise.try.call(null, () => {})).toThrowErrorMatchingInlineSnapshot(
-      `[TypeError: 必须通过 Promise.try 方式调用]`,
-    );
+    expect(() => ClPromise.try.call(null, () => {})).toThrow();
 
     expect(promiseTry(() => {})).toBeInstanceOf(Promise);
     expect(promiseTry((a: number) => a, 1)).resolves.toBe(1);


### PR DESCRIPTION
修复问题：
对于分支是以 `/` 分割的会识别不了导致下载失败

测试图片：
- 文件中使用
<img width="2168" height="1438" alt="image" src="https://github.com/user-attachments/assets/074b92eb-8037-41ce-a996-d418f96f730b" />

- CLI 使用：
<img width="2436" height="1404" alt="image" src="https://github.com/user-attachments/assets/44381108-8d65-4d4d-b3f3-019e0de2f70c" />
